### PR TITLE
added delete functionality for posts

### DIFF
--- a/Tabloid/Repositories/PostRepository.cs
+++ b/Tabloid/Repositories/PostRepository.cs
@@ -196,7 +196,7 @@ namespace Tabloid.Repositories
                 }
             }
         }
-        // Need to implement cascade DELETE to PostReaction, Comment, PostTag
+        
         public void DeletePost(int id)
         {
             using (var conn = Connection)
@@ -204,7 +204,10 @@ namespace Tabloid.Repositories
                 conn.Open();
                 using (var cmd = conn.CreateCommand())
                 {
-                    cmd.CommandText = "DELETE FROM Post WHERE Id = @Id";
+                    cmd.CommandText = @"DELETE PostTag WHERE PostId = @Id;
+                                        DELETE Comment WHERE PostId = @Id;
+                                        DELETE PostReaction WHERE PostId = @Id;
+                                        DELETE FROM Post WHERE Id = @Id;";
                     DbUtils.AddParameter(cmd, "@id", id);
                     cmd.ExecuteNonQuery();
                 }

--- a/Tabloid/client/public/index.html
+++ b/Tabloid/client/public/index.html
@@ -1,21 +1,27 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
-    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
+    <head>
+        <meta charset="utf-8" />
+        <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <meta name="theme-color" content="#000000" />
+        <meta
+            name="description"
+            content="Web site created using create-react-app"
+        />
+        <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+        <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
-    <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
+        <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+        <link
+            rel="stylesheet"
+            href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css"
+            integrity="sha512-iBBXm8fW90+nuLcSKlbmrPcLa0OT92xO1BIsZ+ywDWZCvqsWgccV3gFoRBv0z+8dLJgyAHIhR35VZc2oM/gI1w=="
+            crossorigin="anonymous"
+        />
+        <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.
       Only files inside the `public` folder can be referenced from the HTML.
@@ -24,12 +30,12 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
-  </head>
-  <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
-    <!--
+        <title>React App</title>
+    </head>
+    <body>
+        <noscript>You need to enable JavaScript to run this app.</noscript>
+        <div id="root"></div>
+        <!--
       This HTML file is a template.
       If you open it directly in the browser, you will see an empty page.
 
@@ -38,6 +44,5 @@
 
       To begin the development, run `npm start` or `yarn start`.
       To create a production bundle, use `npm run build` or `yarn build`.
-    -->
-  </body>
+    --></body>
 </html>

--- a/Tabloid/client/src/components/posts/PostDetails.js
+++ b/Tabloid/client/src/components/posts/PostDetails.js
@@ -11,7 +11,13 @@ export const PostDetails = () => {
     const history = useHistory();
 
     useEffect(() => {
-        getPostById(id).then(setPost);
+        getPostById(id).then((parsed) => {
+            if (parsed.id) {
+                setPost(parsed);
+            } else {
+                history.push('/posts');
+            }
+        });
     }, []);
 
     const handleDelete = () => {
@@ -27,13 +33,7 @@ export const PostDetails = () => {
         return date;
     };
 
-    //think about async
-    if (!post) {
-        history.push('/posts');
-        return null;
-    }
-
-    return (
+    return post ? (
         <div className="container">
             <div className="row justify-content-center">
                 <div className="col-sm-12 col-lg-6">
@@ -71,5 +71,5 @@ export const PostDetails = () => {
                 </div>
             </div>
         </div>
-    );
+    ) : null;
 };

--- a/Tabloid/client/src/components/posts/PostDetails.js
+++ b/Tabloid/client/src/components/posts/PostDetails.js
@@ -1,26 +1,36 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { useParams, useHistory } from 'react-router-dom';
 import { PostContext } from '../../providers/PostProvider';
+import { UserProfileContext } from '../../providers/UserProfileProvider';
 
 export const PostDetails = () => {
     const { id } = useParams();
     const [post, setPost] = useState();
-    const { getPostById } = useContext(PostContext);
+    const { getPostById, deletePost } = useContext(PostContext);
+    const { currentUserId } = useContext(UserProfileContext);
     const history = useHistory();
 
     useEffect(() => {
         getPostById(id).then(setPost);
     }, []);
 
+    const handleDelete = () => {
+        if (window.confirm('Are you sure?')) {
+            deletePost(post.id).then(() => {
+                history.push(`/posts/userposts/${currentUserId}`);
+            });
+        }
+    };
+
     const handleDate = () => {
         let date = new Date(post.publishDateTime).toLocaleDateString('en-US');
         return date;
     };
 
-    //think about asyn
+    //think about async
     if (!post) {
+        history.push('/posts');
         return null;
-        // history.push("/posts");
     }
 
     return (
@@ -45,10 +55,15 @@ export const PostDetails = () => {
                             <strong>Publication Date:</strong> {handleDate()}
                         </p>
                         <p>
-                            <p>
-                                <strong>Category:</strong> {post.category.name}
-                            </p>
+                            <strong>Category:</strong> {post.category.name}
                         </p>
+                        {currentUserId === post.userProfileId ? (
+                            <i
+                                className="fas fa-trash-alt fa-2x"
+                                onClick={handleDelete}
+                                style={{ cursor: 'pointer' }}
+                            ></i>
+                        ) : null}
                     </div>
 
                     <p>{post.content}</p>

--- a/Tabloid/client/src/components/posts/PostListCard.js
+++ b/Tabloid/client/src/components/posts/PostListCard.js
@@ -1,8 +1,20 @@
-import React from 'react';
+import React, { useContext } from 'react';
+import { useHistory } from 'react-router-dom';
 import { Link } from 'react-router-dom';
 import { Card, CardImg, CardBody } from 'reactstrap';
+import { PostContext } from '../../providers/PostProvider';
 
 const Post = ({ post }) => {
+    const { deletePost, getAllPosts } = useContext(PostContext);
+    const history = useHistory();
+
+    const handleDelete = () => {
+        if (window.confirm('Are you sure?')) {
+            deletePost(post.id).then(getAllPosts);
+            history.push('/posts');
+        }
+    };
+
     return (
         <Card className="m-4">
             <p className="text-left px-2">
@@ -17,6 +29,12 @@ const Post = ({ post }) => {
                 </p>
 
                 <p>Category: {post.category.name}</p>
+                <Link to="/">Edit</Link>
+                <i
+                    className="fas fa-trash-alt fa-2x"
+                    onClick={handleDelete}
+                    style={{ cursor: 'pointer' }}
+                ></i>
             </CardBody>
         </Card>
     );

--- a/Tabloid/client/src/providers/PostProvider.js
+++ b/Tabloid/client/src/providers/PostProvider.js
@@ -47,9 +47,26 @@ export const PostProvider = (props) => {
         );
     };
 
+    const deletePost = (id) => {
+        return getToken().then((token) =>
+            fetch(`/api/posts/${id}`, {
+                method: 'DELETE',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            })
+        );
+    };
+
     return (
         <PostContext.Provider
-            value={{ posts, getAllPosts, getPostById, getPostsByUserProfileId }}
+            value={{
+                posts,
+                getAllPosts,
+                getPostById,
+                getPostsByUserProfileId,
+                deletePost,
+            }}
         >
             {props.children}
         </PostContext.Provider>


### PR DESCRIPTION
### Changes:
- added cascading deletion to `DeletePost` method in `PostRepository`
- added `deletePost` method to `PostProvider`
- added font-awesome link to index.html
- added affordance for deleting posts to PostList (not limited to author's posts) and PostDetail (limited to author's posts)
---
### Testing:
- fetch and run API and app
- navigate to My Posts link in Navbar to view posts for the logged in user only and select a post to view the Details page
- query any comments that may be associated with any of the current user's posts in SQL and make note of their presence
- in the app, click the trash can to delete the post, click OK on the confirmation dialog
- you should be sent back to the My Posts list and the post you deleted should be gone
- re-run the SQL query to verify that any associated comments were also deleted