### PR TITLE
Deactivate and Reactivate User Profiles

### DIFF
--- a/SQL/01_Tabloid_Create_DB.sql
+++ b/SQL/01_Tabloid_Create_DB.sql
@@ -21,12 +21,14 @@ DROP TABLE IF EXISTS [UserType];
 GO
 
 
-CREATE TABLE [UserType] (
+CREATE TABLE [UserType]
+(
   [Id] integer PRIMARY KEY IDENTITY,
   [Name] nvarchar(20) NOT NULL
 )
 
-CREATE TABLE [UserProfile] (
+CREATE TABLE [UserProfile]
+(
   [Id] integer PRIMARY KEY IDENTITY,
   [FirebaseUserId] NVARCHAR(28) NOT NULL,
   [DisplayName] nvarchar(50) NOT NULL,
@@ -36,12 +38,14 @@ CREATE TABLE [UserProfile] (
   [CreateDateTime] datetime NOT NULL,
   [ImageLocation] nvarchar(255),
   [UserTypeId] integer NOT NULL,
+  [IsDeactivated] bit NOT NULL DEFAULT(0)
 
-  CONSTRAINT [FK_User_UserType] FOREIGN KEY ([UserTypeId]) REFERENCES [UserType] ([Id]),
+    CONSTRAINT [FK_User_UserType] FOREIGN KEY ([UserTypeId]) REFERENCES [UserType] ([Id]),
   CONSTRAINT UQ_FirebaseUserId UNIQUE(FirebaseUserId)
 )
 
-CREATE TABLE [Subscription] (
+CREATE TABLE [Subscription]
+(
   [Id] integer PRIMARY KEY IDENTITY,
   [SubscriberUserProfileId] integer NOT NULL,
   [ProviderUserProfileId] integer NOT NULL,
@@ -55,12 +59,14 @@ CREATE TABLE [Subscription] (
 	REFERENCES [UserProfile] ([Id])
 )
 
-CREATE TABLE [Category] (
+CREATE TABLE [Category]
+(
   [Id] integer PRIMARY KEY IDENTITY,
   [Name] nvarchar(50) NOT NULL
 )
 
-CREATE TABLE [Post] (
+CREATE TABLE [Post]
+(
   [Id] integer PRIMARY KEY IDENTITY,
   [Title] nvarchar(255) NOT NULL,
   [Content] text NOT NULL,
@@ -75,7 +81,8 @@ CREATE TABLE [Post] (
   CONSTRAINT [FK_Post_UserProfile] FOREIGN KEY ([UserProfileId]) REFERENCES [UserProfile] ([Id])
 )
 
-CREATE TABLE [Comment] (
+CREATE TABLE [Comment]
+(
   [Id] integer PRIMARY KEY IDENTITY,
   [PostId] integer NOT NULL,
   [UserProfileId] integer NOT NULL,
@@ -87,27 +94,31 @@ CREATE TABLE [Comment] (
   CONSTRAINT [FK_Comment_UserProfile] FOREIGN KEY ([UserProfileId]) REFERENCES [UserProfile] ([Id])
 )
 
-CREATE TABLE [Tag] (
+CREATE TABLE [Tag]
+(
   [Id] integer PRIMARY KEY IDENTITY,
   [Name] nvarchar(50) NOT NULL
 )
 
-CREATE TABLE [PostTag] (
+CREATE TABLE [PostTag]
+(
   [id] integer PRIMARY KEY IDENTITY,
   [PostId] integer NOT NULL,
   [TagId] integer NOT NULL,
-  
+
   CONSTRAINT [FK_PostTag_Post] FOREIGN KEY ([PostId]) REFERENCES [Post] ([Id]),
   CONSTRAINT [FK_PostTag_Tag] FOREIGN KEY ([TagId]) REFERENCES [Tag] ([Id])
 )
 
-CREATE TABLE [Reaction] (
+CREATE TABLE [Reaction]
+(
   [Id] integer PRIMARY KEY IDENTITY,
   [Name] nvarchar(50) NOT NULL,
   [ImageLocation] nvarchar(255) NOT NULL
 )
 
-CREATE TABLE [PostReaction] (
+CREATE TABLE [PostReaction]
+(
   [Id] integer PRIMARY KEY IDENTITY,
   [PostId] integer NOT NULL,
   [ReactionId] integer NOT NULL,

--- a/Tabloid/Controllers/UserProfileController.cs
+++ b/Tabloid/Controllers/UserProfileController.cs
@@ -20,6 +20,12 @@ namespace Tabloid.Controllers
         {
             return Ok(_userProfileRepository.GetAll());
         }
+        
+        [HttpGet("deactivated")]
+        public IActionResult GetDeactivatedProfiles()
+        {
+            return Ok(_userProfileRepository.GetAllDeactivated());
+        }
 
         [HttpGet("getbyid/{id}")]
         public IActionResult GetUserProfileById(int id)

--- a/Tabloid/Controllers/UserProfileController.cs
+++ b/Tabloid/Controllers/UserProfileController.cs
@@ -39,6 +39,25 @@ namespace Tabloid.Controllers
             return Ok(_userProfileRepository.GetByFirebaseUserId(firebaseUserId));
         }
 
+        [HttpDelete("{id}")]
+        public IActionResult Deactivate(int id)
+        {
+            _userProfileRepository.Deactivate(id);
+            return NoContent();
+        }
+
+        [HttpPut("reactivate/{id}")]
+        public IActionResult Reactivate(int id, UserProfile user)
+        {
+            if (id != user.Id)
+            {
+                return BadRequest();
+            }
+
+            _userProfileRepository.Reactivate(user);
+            return NoContent();
+        }
+
         [HttpPost]
         public IActionResult Post(UserProfile userProfile)
         {

--- a/Tabloid/Models/UserProfile.cs
+++ b/Tabloid/Models/UserProfile.cs
@@ -38,6 +38,7 @@ namespace Tabloid.Models
         [Required]
         public int UserTypeId { get; set; }
         public UserType UserType { get; set; }
+        public bool IsDeactivated { get; set; }
 
         public string FullName
         {

--- a/Tabloid/Repositories/IUserProfileRepository.cs
+++ b/Tabloid/Repositories/IUserProfileRepository.cs
@@ -9,5 +9,6 @@ namespace Tabloid.Repositories
         UserProfile GetByFirebaseUserId(string firebaseUserId);
         List<UserProfile> GetAll();
         UserProfile GetByUserProfileId(int id);
+        List<UserProfile> GetAllDeactivated();
     }
 }

--- a/Tabloid/Repositories/IUserProfileRepository.cs
+++ b/Tabloid/Repositories/IUserProfileRepository.cs
@@ -10,5 +10,7 @@ namespace Tabloid.Repositories
         List<UserProfile> GetAll();
         UserProfile GetByUserProfileId(int id);
         List<UserProfile> GetAllDeactivated();
+        void Deactivate(int userProfileId);
+        void Reactivate(UserProfile user);
     }
 }

--- a/Tabloid/Repositories/UserProfileRepository.cs
+++ b/Tabloid/Repositories/UserProfileRepository.cs
@@ -19,10 +19,37 @@ namespace Tabloid.Repositories
                 {
                     cmd.CommandText = @"
                         SELECT up.Id, up.FirebaseUserId, up.FirstName, up.LastName, up.DisplayName,
-                        up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId,
+                        up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId, up.IsDeactivated,
                         ut.Name AS UserTypeName
                         FROM UserProfile up
-                        LEFT JOIN UserType ut ON up.UserTypeId = ut.Id";
+                        LEFT JOIN UserType ut ON up.UserTypeId = ut.Id
+                        WHERE up.IsDeactivated = 0";
+                    var reader = cmd.ExecuteReader();
+                    var userProfiles = new List<UserProfile>();
+                    while (reader.Read())
+                    {
+                        userProfiles.Add(NewUserProfileFromDb(reader));
+                    }
+                    reader.Close();
+                    return userProfiles;
+                }
+            }
+        }
+
+        public List<UserProfile> GetAllDeactivated()
+        {
+            using (var conn = Connection)
+            {
+                conn.Open();
+                using (var cmd = conn.CreateCommand())
+                {
+                    cmd.CommandText = @"
+                        SELECT up.Id, up.FirebaseUserId, up.FirstName, up.LastName, up.DisplayName,
+                        up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId, up.IsDeactivated,
+                        ut.Name AS UserTypeName
+                        FROM UserProfile up
+                        LEFT JOIN UserType ut ON up.UserTypeId = ut.Id
+                        WHERE up.IsDeactivated = 1";
                     var reader = cmd.ExecuteReader();
                     var userProfiles = new List<UserProfile>();
                     while (reader.Read())
@@ -44,7 +71,7 @@ namespace Tabloid.Repositories
                 {
                     cmd.CommandText = @"
                         SELECT up.Id, Up.FirebaseUserId, up.FirstName, up.LastName, up.DisplayName, 
-                               up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId,
+                               up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId, up.IsDeactivated,
                                ut.Name AS UserTypeName
                           FROM UserProfile up
                                LEFT JOIN UserType ut on up.UserTypeId = ut.Id
@@ -76,7 +103,7 @@ namespace Tabloid.Repositories
                 {
                     cmd.CommandText = @"
                         SELECT up.Id, Up.FirebaseUserId, up.FirstName, up.LastName, up.DisplayName, 
-                               up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId,
+                               up.Email, up.CreateDateTime, up.ImageLocation, up.UserTypeId, up.IsDeactivated,
                                ut.Name AS UserTypeName
                           FROM UserProfile up
                                LEFT JOIN UserType ut on up.UserTypeId = ut.Id
@@ -137,6 +164,7 @@ namespace Tabloid.Repositories
                 CreateDateTime = DbUtils.GetDateTime(reader, "CreateDateTime"),
                 ImageLocation = DbUtils.GetString(reader, "ImageLocation"),
                 UserTypeId = DbUtils.GetInt(reader, "UserTypeId"),
+                IsDeactivated= reader.GetBoolean(reader.GetOrdinal("IsDeactivated")),
                 UserType = new UserType()
                 {
                     Id = DbUtils.GetInt(reader, "UserTypeId"),

--- a/Tabloid/client/src/components/userProfiles/UserProfileCard.js
+++ b/Tabloid/client/src/components/userProfiles/UserProfileCard.js
@@ -1,8 +1,31 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { Link, useHistory } from 'react-router-dom';
 import { Card, CardBody } from 'reactstrap';
+import { UserProfileContext } from '../../providers/UserProfileProvider';
 
 export const UserProfileCard = ({ userProfile }) => {
+    const {
+        deactivateUserProfile,
+        reactivateUserProfile,
+        setViewingDeactivated,
+    } = useContext(UserProfileContext);
+    const history = useHistory();
+
+    const handleDeactivate = () => {
+        if (window.confirm('Are you sure you want to deactivate this user?')) {
+            deactivateUserProfile(userProfile.id).then(() => {
+                history.push('/userprofile');
+            });
+        }
+    };
+
+    const handleReactivate = () => {
+        reactivateUserProfile(userProfile).then(() => {
+            setViewingDeactivated(false);
+            history.push('/userprofile');
+        });
+    };
+
     return (
         <Card className="m-4">
             <Link to={`/userprofile/${userProfile.id}`}>
@@ -11,6 +34,15 @@ export const UserProfileCard = ({ userProfile }) => {
             <CardBody>
                 <p>Full Name: {userProfile.fullName}</p>
                 <p>User Role: {userProfile.userType.name}</p>
+                {userProfile.isDeactivated ? (
+                    <p onClick={handleReactivate} style={{ cursor: 'pointer' }}>
+                        Reactivate User
+                    </p>
+                ) : (
+                    <p onClick={handleDeactivate} style={{ cursor: 'pointer' }}>
+                        Deactivate User
+                    </p>
+                )}
             </CardBody>
         </Card>
     );

--- a/Tabloid/client/src/components/userProfiles/UserProfileCard.js
+++ b/Tabloid/client/src/components/userProfiles/UserProfileCard.js
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { Link, useHistory } from 'react-router-dom';
-import { Card, CardBody } from 'reactstrap';
+import { Card, CardBody, Button } from 'reactstrap';
 import { UserProfileContext } from '../../providers/UserProfileProvider';
 
 export const UserProfileCard = ({ userProfile }) => {
@@ -34,15 +34,17 @@ export const UserProfileCard = ({ userProfile }) => {
             <CardBody>
                 <p>Full Name: {userProfile.fullName}</p>
                 <p>User Role: {userProfile.userType.name}</p>
-                {userProfile.isDeactivated ? (
-                    <p onClick={handleReactivate} style={{ cursor: 'pointer' }}>
-                        Reactivate User
-                    </p>
-                ) : (
-                    <p onClick={handleDeactivate} style={{ cursor: 'pointer' }}>
-                        Deactivate User
-                    </p>
-                )}
+                <div className="text-center">
+                    {userProfile.isDeactivated ? (
+                        <Button onClick={handleReactivate} color="success">
+                            Reactivate User
+                        </Button>
+                    ) : (
+                        <Button onClick={handleDeactivate} color="danger">
+                            Deactivate User
+                        </Button>
+                    )}
+                </div>
             </CardBody>
         </Card>
     );

--- a/Tabloid/client/src/components/userProfiles/UserProfileDetails.js
+++ b/Tabloid/client/src/components/userProfiles/UserProfileDetails.js
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useContext } from 'react';
-import { useParams, useHistory } from 'react-router-dom';
+import { useParams, useHistory, Link } from 'react-router-dom';
 import { UserProfileContext } from '../../providers/UserProfileProvider';
 
 export const UserProfileDetails = (params) => {
@@ -35,6 +35,7 @@ export const UserProfileDetails = (params) => {
                     </p>
                     <p>Email: {userProfile.email}</p>
                     <p>User type: {userProfile.userType.name}</p>
+                    <Link to="/userprofile">Back To User Profiles List</Link>
                 </div>
             </div>
         </div>

--- a/Tabloid/client/src/components/userProfiles/UserProfileList.js
+++ b/Tabloid/client/src/components/userProfiles/UserProfileList.js
@@ -1,19 +1,56 @@
 import React, { useContext, useEffect, useState } from 'react';
+import { Button } from 'reactstrap';
 import { UserProfileContext } from '../../providers/UserProfileProvider';
 import { UserProfileCard } from './UserProfileCard';
 
 export const UserProfileList = () => {
-    const { getAllUserProfiles } = useContext(UserProfileContext);
+    const { getAllUserProfiles, getDeactivatedUserProfiles } = useContext(
+        UserProfileContext
+    );
     const [allProfiles, setAllProfiles] = useState([]);
+    const [viewingDeactivated, setViewingDeactivated] = useState(false);
 
     useEffect(() => {
         getAllUserProfiles().then(setAllProfiles);
     }, []);
 
+    useEffect(() => {
+        if (viewingDeactivated) {
+            getDeactivatedUserProfiles().then(setAllProfiles);
+        } else {
+            getAllUserProfiles().then(setAllProfiles);
+        }
+    }, [viewingDeactivated]);
+
     return (
         <div className="container">
             <div className="row justify-content-center">
                 <div className="cards-column">
+                    <div className="text-center">
+                        {viewingDeactivated ? (
+                            <h1>Deactivated Users</h1>
+                        ) : (
+                            <h1>Active Users</h1>
+                        )}
+                        {viewingDeactivated ? (
+                            <Button
+                                color="success"
+                                onClick={() => {
+                                    setViewingDeactivated(false);
+                                }}
+                            >
+                                View Active Users
+                            </Button>
+                        ) : (
+                            <Button
+                                onClick={() => {
+                                    setViewingDeactivated(true);
+                                }}
+                            >
+                                View Deactivated Users
+                            </Button>
+                        )}
+                    </div>
                     {allProfiles
                         .sort((a, b) =>
                             a.displayName.localeCompare(b.displayName)

--- a/Tabloid/client/src/components/userProfiles/UserProfileList.js
+++ b/Tabloid/client/src/components/userProfiles/UserProfileList.js
@@ -4,21 +4,23 @@ import { UserProfileContext } from '../../providers/UserProfileProvider';
 import { UserProfileCard } from './UserProfileCard';
 
 export const UserProfileList = () => {
-    const { getAllUserProfiles, getDeactivatedUserProfiles } = useContext(
-        UserProfileContext
-    );
-    const [allProfiles, setAllProfiles] = useState([]);
-    const [viewingDeactivated, setViewingDeactivated] = useState(false);
+    const {
+        getAllUserProfiles,
+        getDeactivatedUserProfiles,
+        userProfiles,
+        viewingDeactivated,
+        setViewingDeactivated,
+    } = useContext(UserProfileContext);
 
     useEffect(() => {
-        getAllUserProfiles().then(setAllProfiles);
+        getAllUserProfiles();
     }, []);
 
     useEffect(() => {
         if (viewingDeactivated) {
-            getDeactivatedUserProfiles().then(setAllProfiles);
+            getDeactivatedUserProfiles();
         } else {
-            getAllUserProfiles().then(setAllProfiles);
+            getAllUserProfiles();
         }
     }, [viewingDeactivated]);
 
@@ -51,7 +53,7 @@ export const UserProfileList = () => {
                             </Button>
                         )}
                     </div>
-                    {allProfiles
+                    {userProfiles
                         .sort((a, b) =>
                             a.displayName.localeCompare(b.displayName)
                         )

--- a/Tabloid/client/src/providers/UserProfileProvider.js
+++ b/Tabloid/client/src/providers/UserProfileProvider.js
@@ -11,6 +11,8 @@ export function UserProfileProvider(props) {
     const userProfile = sessionStorage.getItem('userProfile');
     const [isLoggedIn, setIsLoggedIn] = useState(userProfile != null);
     const [currentUserId, setCurrentUserId] = useState(0);
+    const [userProfiles, setUserProfiles] = useState([]);
+    const [viewingDeactivated, setViewingDeactivated] = useState(false);
 
     const [isFirebaseReady, setIsFirebaseReady] = useState(false);
     useEffect(() => {
@@ -77,7 +79,9 @@ export function UserProfileProvider(props) {
                 headers: {
                     Authorization: `Bearer ${token}`,
                 },
-            }).then((res) => res.json())
+            })
+                .then((res) => res.json())
+                .then(setUserProfiles)
         );
     };
 
@@ -88,7 +92,9 @@ export function UserProfileProvider(props) {
                 headers: {
                     Authorization: `Bearer ${token}`,
                 },
-            }).then((res) => res.json())
+            })
+                .then((res) => res.json())
+                .then(setUserProfiles)
         );
     };
 
@@ -127,6 +133,30 @@ export function UserProfileProvider(props) {
         );
     };
 
+    const deactivateUserProfile = (userProfileId) => {
+        return getToken().then((token) =>
+            fetch(`${apiUrl}/${userProfileId}`, {
+                method: 'DELETE',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            }).then(getAllUserProfiles)
+        );
+    };
+
+    const reactivateUserProfile = (userProfile) => {
+        return getToken().then((token) =>
+            fetch(`${apiUrl}/reactivate/${userProfile.id}`, {
+                method: 'PUT',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                    'Content-Type': 'application/json',
+                },
+                body: JSON.stringify(userProfile),
+            }).then(getAllUserProfiles)
+        );
+    };
+
     return (
         <UserProfileContext.Provider
             value={{
@@ -139,6 +169,12 @@ export function UserProfileProvider(props) {
                 getAllUserProfiles,
                 getUserProfileById,
                 getDeactivatedUserProfiles,
+                deactivateUserProfile,
+                reactivateUserProfile,
+                userProfiles,
+                setUserProfiles,
+                viewingDeactivated,
+                setViewingDeactivated,
             }}
         >
             {isFirebaseReady ? (

--- a/Tabloid/client/src/providers/UserProfileProvider.js
+++ b/Tabloid/client/src/providers/UserProfileProvider.js
@@ -81,6 +81,17 @@ export function UserProfileProvider(props) {
         );
     };
 
+    const getDeactivatedUserProfiles = () => {
+        return getToken().then((token) =>
+            fetch(`${apiUrl}/deactivated`, {
+                method: 'GET',
+                headers: {
+                    Authorization: `Bearer ${token}`,
+                },
+            }).then((res) => res.json())
+        );
+    };
+
     const getUserProfileById = (id) => {
         return getToken().then((token) =>
             fetch(`${apiUrl}/getbyid/${id}`, {
@@ -127,6 +138,7 @@ export function UserProfileProvider(props) {
                 currentUserId,
                 getAllUserProfiles,
                 getUserProfileById,
+                getDeactivatedUserProfiles,
             }}
         >
             {isFirebaseReady ? (


### PR DESCRIPTION
### Changes:
- updated SQL DB create script to include IsDeactivated on UserProfile
- added `IsDeactivated` to `UserProfile` model
- added controller and repository methods to deactivate and reactivate user profiles
- added methods to `UserProfileProvider` to deactivate and reactivate user profiles
- added affordances to `UserProfileCard` for deletion and reactivation of users
- added toggle to `UserProfileList` to view active or inactive profiles
---
### Testing:
- fetch and run app and API
- log in
- navigate to User Profile Management in the Admin Menu on the navbar
- click the "Deactivate User" in a user card and select "OK" from the confirmation dialog to deactivate a user
- click the "View Deactivated Users" button to view the users who are currently deactivated
- click "Reactivate User" on the user you just deactivated to reactivate them and be sent back to the Active Users list