### PR TITLE
AR Prevent loss of last admin

### DIFF
--- a/Tabloid/Controllers/UserProfileController.cs
+++ b/Tabloid/Controllers/UserProfileController.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Linq;
 using Tabloid.Models;
 using Tabloid.Repositories;
 
@@ -20,7 +21,7 @@ namespace Tabloid.Controllers
         {
             return Ok(_userProfileRepository.GetAll());
         }
-        
+
         [HttpGet("deactivated")]
         public IActionResult GetDeactivatedProfiles()
         {
@@ -42,8 +43,15 @@ namespace Tabloid.Controllers
         [HttpDelete("{id}")]
         public IActionResult Deactivate(int id)
         {
-            _userProfileRepository.Deactivate(id);
-            return NoContent();
+            int adminCount = _userProfileRepository.GetAll().Where(up => up.UserTypeId == 1).ToList().Count;
+            if (adminCount > 1)
+            {
+                _userProfileRepository.Deactivate(id);
+                return NoContent();
+            } else
+            {
+                return BadRequest("Cannot delete the sole admin. Please elevate another user and try again.");
+            }
         }
 
         [HttpPut("reactivate/{id}")]

--- a/Tabloid/client/src/providers/UserProfileProvider.js
+++ b/Tabloid/client/src/providers/UserProfileProvider.js
@@ -140,7 +140,16 @@ export function UserProfileProvider(props) {
                 headers: {
                     Authorization: `Bearer ${token}`,
                 },
-            }).then(getAllUserProfiles)
+            })
+                .then((res) => {
+                    if (!res.ok) {
+                        throw Error(
+                            'Cannot delete the sole admin. Please elevate another user and try again.'
+                        );
+                    }
+                })
+                .then(getAllUserProfiles)
+                .catch((error) => window.alert(error))
         );
     };
 


### PR DESCRIPTION
### Changes:
- added logic to `UserProfileController` to check number of admins upon deactivation requests. If there is only one admin, it won't work.
- added alert to `UserProfileProvider` to notify the user if a deletion request fails
---
### Testing:
- fetch branch, run app and API
- log in as an admin user
- navigate to User Profile Management in the Admin Menu
- deactivate all the Admin profiles. When only one remains, you should be unable to deactivate it